### PR TITLE
Add Cohen's Kappa metric and rename perf to principle strength

### DIFF
--- a/src/feedback_forensics/app/metrics.py
+++ b/src/feedback_forensics/app/metrics.py
@@ -26,14 +26,14 @@ def get_acc(value_counts: pd.Series) -> float:
 
 def get_cohens_kappa(value_counts: pd.Series) -> float:
     """
-    Cohen's Kappa: measures agreement beyond chance.
+    Cohen's kappa: measures agreement beyond chance.
 
     Since the ICAI principle annotator randomizes the order of the alternatives
     (see the function `get_preference_vote_for_single_text` in ICAI), it has no
     position bias and the probability of chance agreement is 50% (even if the
-    dataset has position bias. Therefore, the calculation simplifies to
+    dataset has position bias). Therefore, the calculation simplifies to
 
-    Cohen's Kappa = (accuracy - 0.5) / 0.5 = 2 * (accuracy - 0.5)
+    Cohen's kappa = (accuracy - 0.5) / 0.5 = 2 * (accuracy - 0.5)
 
     This ranges from -1 (perfect disagreement) through 0 (random agreement)
     to 1 (perfect agreement).
@@ -55,9 +55,9 @@ def get_relevance(value_counts: pd.Series) -> float:
 
 def get_principle_strength(value_counts: pd.Series) -> float:
     """
-    Relevance-weighted Cohen's Kappa: combines Cohen's Kappa with relevance.
+    Relevance-weighted Cohen's kappa: combines Cohen's kappa with relevance.
 
-    This is computed as: (Cohen's Kappa) * relevance
+    This is computed as: (Cohen's kappa) * relevance
     which simplifies to: 2 * (accuracy - 0.5) * relevance
     """
     cohens_kappa = get_cohens_kappa(value_counts)
@@ -183,14 +183,14 @@ METRIC_COL_OPTIONS = {
         "descr": "Relevance: proportion of all votes that are not 'not applicable'",
     },
     "principle_strength": {
-        "name": "Principle strength (Relevance-weighted Cohen's Kappa)",
+        "name": "Principle strength (Relevance-weighted Cohen's kappa)",
         "short": "strength",
-        "descr": "Principle strength: relevance * Cohen's Kappa, or relevance * 2 * (accuracy - 0.5)",
+        "descr": "Principle strength: relevance * Cohen's kappa, or relevance * 2 * (accuracy - 0.5)",
     },
     "cohens_kappa": {
-        "name": "Cohen's Kappa",
-        "short": "Kappa",
-        "descr": "Cohen's Kappa: measures agreement beyond chance, 2 * (accuracy - 0.5).",
+        "name": "Cohen's kappa",
+        "short": "kappa",
+        "descr": "Cohen's kappa: measures agreement beyond chance, 2 * (accuracy - 0.5).",
     },
     "principle_strength_base": {
         "name": "Principle strength on full dataset",
@@ -249,7 +249,7 @@ def get_ordering_options(
             metrics["metrics"]["principle_strength"]["principle_order"],
         ],
         "cohens_kappa": [
-            "Cohen's Kappa ↓",
+            "Cohen's kappa ↓",
             metrics["metrics"]["cohens_kappa"]["principle_order"],
         ],
         "principle_strength_base": [

--- a/src/feedback_forensics/app/metrics.py
+++ b/src/feedback_forensics/app/metrics.py
@@ -54,9 +54,15 @@ def get_relevance(value_counts: pd.Series) -> float:
 
 
 def get_perf(value_counts: pd.Series) -> float:
-    acc = get_acc(value_counts)
+    """
+    Relevance-weighted Cohen's Kappa: combines Cohen's Kappa with relevance.
+
+    This is computed as: (Cohen's Kappa) * relevance
+    which simplifies to: 2 * (accuracy - 0.5) * relevance
+    """
+    cohens_kappa = get_cohens_kappa(value_counts)
     relevance = get_relevance(value_counts)
-    return (acc - 0.5) * relevance * 2
+    return cohens_kappa * relevance
 
 
 def get_num_votes(value_counts: pd.Series) -> int:
@@ -179,7 +185,7 @@ METRIC_COL_OPTIONS = {
     "perf": {
         "name": "Performance",
         "short": "Perf.",
-        "descr": "Performance: relevance * (accuracy - 0.5) * 2",
+        "descr": "Performance: relevance * Cohen's Kappa, or relevance * 2 * (accuracy - 0.5)",
     },
     "cohens_kappa": {
         "name": "Cohen's Kappa",

--- a/src/feedback_forensics/app/metrics.py
+++ b/src/feedback_forensics/app/metrics.py
@@ -12,14 +12,14 @@ def get_acc(value_counts: pd.Series) -> float:
     Accuracy: proportion of non-irrelevant votes ('agree' or 'disagree')
     that agree with original preferences.
 
-    If there are no non-irrelevant votes, return 0.
+    If there are no non-irrelevant votes, return 0.5.
     """
     num_agreed = value_counts.get("Agree", 0)
     num_disagreed = value_counts.get("Disagree", 0)
 
     denominator = num_agreed + num_disagreed
     if denominator == 0:
-        return 0
+        return 0.5
     else:
         return num_agreed / denominator
 

--- a/src/feedback_forensics/app/metrics.py
+++ b/src/feedback_forensics/app/metrics.py
@@ -53,7 +53,7 @@ def get_relevance(value_counts: pd.Series) -> float:
     ) / value_counts.sum()
 
 
-def get_perf(value_counts: pd.Series) -> float:
+def get_principle_strength(value_counts: pd.Series) -> float:
     """
     Relevance-weighted Cohen's Kappa: combines Cohen's Kappa with relevance.
 
@@ -90,7 +90,7 @@ def compute_metrics(votes_df: pd.DataFrame, baseline_metrics: dict = None) -> di
         "agreement": get_agreement,
         "acc": get_acc,
         "relevance": get_relevance,
-        "perf": get_perf,
+        "strength": get_principle_strength,
         "cohens_kappa": get_cohens_kappa,
         "num_votes": get_num_votes,
         "agreed": get_agreed,
@@ -182,25 +182,25 @@ METRIC_COL_OPTIONS = {
         "short": "Rel.",
         "descr": "Relevance: proportion of all votes that are not 'not applicable'",
     },
-    "perf": {
-        "name": "Performance",
-        "short": "Perf.",
-        "descr": "Performance: relevance * Cohen's Kappa, or relevance * 2 * (accuracy - 0.5)",
+    "principle_strength": {
+        "name": "Principle strength (Relevance-weighted Cohen's Kappa)",
+        "short": "strength",
+        "descr": "Principle strength: relevance * Cohen's Kappa, or relevance * 2 * (accuracy - 0.5)",
     },
     "cohens_kappa": {
         "name": "Cohen's Kappa",
         "short": "Kappa",
         "descr": "Cohen's Kappa: measures agreement beyond chance, 2 * (accuracy - 0.5).",
     },
-    "perf_base": {
-        "name": "Performance on full dataset",
+    "principle_strength_base": {
+        "name": "Principle strength on full dataset",
         "short": "(all)",
-        "descr": "Performance on all datapoints (not just selected subset)",
+        "descr": "Principle strength on all datapoints (not just selected subset)",
     },
-    "perf_diff": {
-        "name": "Performance difference (full vs subset)",
+    "principle_strength_diff": {
+        "name": "Principle strength difference (full vs subset)",
         "short": "(diff)",
-        "descr": "Absolute performance difference to votes on entire dataset",
+        "descr": "Absolute principle strength difference to votes on entire dataset",
     },
 }
 
@@ -244,18 +244,21 @@ def get_ordering_options(
             "Relevance ↓",
             metrics["metrics"]["relevance"]["principle_order"],
         ],
-        "perf": ["Performance ↓", metrics["metrics"]["perf"]["principle_order"]],
+        "principle_strength": [
+            "Principle strength ↓",
+            metrics["metrics"]["principle_strength"]["principle_order"],
+        ],
         "cohens_kappa": [
             "Cohen's Kappa ↓",
             metrics["metrics"]["cohens_kappa"]["principle_order"],
         ],
-        "perf_base": [
-            "Performance on full dataset ↓",
-            metrics["metrics"]["perf_base"]["principle_order"],
+        "principle_strength_base": [
+            "Principle strength on full dataset ↓",
+            metrics["metrics"]["principle_strength_base"]["principle_order"],
         ],
-        "perf_diff": [
-            "Performance difference ↓",
-            metrics["metrics"]["perf_diff"]["principle_order"],
+        "principle_strength_diff": [
+            "Principle strength difference ↓",
+            metrics["metrics"]["principle_strength_diff"]["principle_order"],
         ],
     }
 

--- a/src/feedback_forensics/app/metrics_test.py
+++ b/src/feedback_forensics/app/metrics_test.py
@@ -9,6 +9,7 @@ from feedback_forensics.app.metrics import (
     get_acc,
     get_relevance,
     get_perf,
+    get_cohens_kappa,
     get_num_votes,
     get_agreed,
     get_disagreed,
@@ -85,6 +86,29 @@ def test_get_perf():
     # Test with neutral performance
     value_counts = pd.Series({"Agree": 2, "Disagree": 2, "Not applicable": 1})
     assert get_perf(value_counts) == 0.0
+
+
+def test_get_cohens_kappa():
+    """Test Cohen's Kappa calculation for different vote distributions."""
+    # Test with perfect agreement
+    value_counts = pd.Series({"Agree": 5, "Disagree": 0, "Not applicable": 0})
+    assert get_cohens_kappa(value_counts) == 1.0  # 2 * (1.0 - 0.5)
+
+    # Test with perfect disagreement
+    value_counts = pd.Series({"Agree": 0, "Disagree": 5, "Not applicable": 0})
+    assert get_cohens_kappa(value_counts) == -1.0  # 2 * (0.0 - 0.5)
+
+    # Test with random performance (equal agree/disagree)
+    value_counts = pd.Series({"Agree": 3, "Disagree": 3, "Not applicable": 2})
+    assert get_cohens_kappa(value_counts) == 0.0  # 2 * (0.5 - 0.5)
+
+    # Test with 75% agreement
+    value_counts = pd.Series({"Agree": 3, "Disagree": 1, "Not applicable": 0})
+    assert get_cohens_kappa(value_counts) == 0.5  # 2 * (0.75 - 0.5)
+
+    # Test with no relevant votes
+    value_counts = pd.Series({"Not applicable": 5})
+    assert get_cohens_kappa(value_counts) == 0.0  # Returns 0 for no relevant votes
 
 
 def test_vote_count_functions():

--- a/src/feedback_forensics/app/metrics_test.py
+++ b/src/feedback_forensics/app/metrics_test.py
@@ -8,7 +8,7 @@ from feedback_forensics.app.metrics import (
     get_agreement,
     get_acc,
     get_relevance,
-    get_perf,
+    get_principle_strength,
     get_cohens_kappa,
     get_num_votes,
     get_agreed,
@@ -71,21 +71,21 @@ def test_get_relevance():
     assert get_relevance(value_counts) == 0.0
 
 
-def test_get_perf():
-    """Test performance calculation for different vote distributions."""
+def test_get_principle_strength():
+    """Test principle strength calculation for different vote distributions."""
     # Test with perfect performance
     value_counts = pd.Series({"Agree": 4, "Disagree": 0, "Not applicable": 1})
     expected = (1.0 - 0.5) * (4 / 5) * 2  # (acc - 0.5) * relevance * 2
-    assert get_perf(value_counts) == expected
+    assert get_principle_strength(value_counts) == expected
 
     # Test with worst performance
     value_counts = pd.Series({"Agree": 0, "Disagree": 4, "Not applicable": 1})
     expected = (0.0 - 0.5) * (4 / 5) * 2
-    assert get_perf(value_counts) == expected
+    assert get_principle_strength(value_counts) == expected
 
     # Test with neutral performance
     value_counts = pd.Series({"Agree": 2, "Disagree": 2, "Not applicable": 1})
-    assert get_perf(value_counts) == 0.0
+    assert get_principle_strength(value_counts) == 0.0
 
 
 def test_get_cohens_kappa():
@@ -145,7 +145,7 @@ def test_compute_metrics():
     # Check metrics for p1
     p1_metrics = {
         metric: metrics["metrics"][metric]["by_principle"]["p1"]
-        for metric in ["agreement", "acc", "relevance", "perf"]
+        for metric in ["agreement", "acc", "relevance", "principle_strength"]
     }
     assert p1_metrics["agreement"] == 0.5  # 1 agree out of 2 total
     assert p1_metrics["acc"] == 1.0  # 1 agree out of 1 relevant vote
@@ -156,8 +156,8 @@ def test_compute_metrics():
     metrics_with_baseline = compute_metrics(votes_df, baseline_metrics=baseline_metrics)
 
     # Check that diff and base metrics exist
-    assert "perf_diff" in metrics_with_baseline["metrics"]
-    assert "perf_base" in metrics_with_baseline["metrics"]
+    assert "principle_strength_diff" in metrics_with_baseline["metrics"]
+    assert "principle_strength_base" in metrics_with_baseline["metrics"]
 
 
 def test_compute_metrics_empty_data():

--- a/src/feedback_forensics/app/metrics_test.py
+++ b/src/feedback_forensics/app/metrics_test.py
@@ -48,7 +48,9 @@ def test_get_acc():
 
     # Test with no relevant votes
     value_counts = pd.Series({"Not applicable": 5})
-    assert get_acc(value_counts) == 0.0
+    assert (
+        get_acc(value_counts) == 0.5
+    )  # When no relevant votes, returns 0.5 (chance level)
 
 
 def test_get_relevance():

--- a/src/feedback_forensics/app/metrics_test.py
+++ b/src/feedback_forensics/app/metrics_test.py
@@ -89,7 +89,7 @@ def test_get_principle_strength():
 
 
 def test_get_cohens_kappa():
-    """Test Cohen's Kappa calculation for different vote distributions."""
+    """Test Cohen's kappa calculation for different vote distributions."""
     # Test with perfect agreement
     value_counts = pd.Series({"Agree": 5, "Disagree": 0, "Not applicable": 0})
     assert get_cohens_kappa(value_counts) == 1.0  # 2 * (1.0 - 0.5)

--- a/src/feedback_forensics/app/plotting_v2/constants.py
+++ b/src/feedback_forensics/app/plotting_v2/constants.py
@@ -43,15 +43,15 @@ the principle relevant to. Ranges from 0 to 1.<br><br>
 <b>Accuracy <i>(acc)</i></b>: Accuracy of principle-following AI annotator <br>
 reconstructing the original annotations, when datapoints are deemed relevant.<br>
 Ranges from 0 to 1.<br><br>
-<b>Performance <i>(perf)</i></b>: Combines accuracy and relevance of a principle,<br>
-ranges from -1 to 1. Calculated as perf=(acc-0.5)×rel×2. A value of 0 indicates<br>
-no predictive performance (either due to random prediction or low relevance),<br>
-values below 0 indicate principle-following AI annotator is worse than random<br>
-annotator, and values above 0 indicate principle-following AI annotator is better<br>
-than random annotator.<br><br>
 <b>Cohen's Kappa <i>(kappa)</i></b>: Measures agreement beyond chance between the<br>
 principle-following AI annotator and original preferences. Calculated as<br>
 kappa=2×(acc-0.5), using 0.5 as the expected agreement by chance for a binary choice.<br>
 Ranges from -1 (perfect disagreement) through 0 (random agreement) to 1 (perfect<br>
-agreement). Unlike Performance, it doesn't take relevance into account.
+agreement). Unlike principle strength, it doesn't take relevance into account.<br><br>
+<b>Principle strength <i>(strength)</i></b>: Combines Cohen's Kappa and relevance,<br>
+ranges from -1 to 1. Calculated as strength = Cohen's Kappa × relevance, which equals<br>
+2×(acc-0.5)×relevance. A value of 0 indicates no predictive performance (either due<br>
+to random prediction or low relevance), values below 0 indicate principle-following<br>
+AI annotator is worse than random annotator, and values above 0 indicate<br>
+principle-following AI annotator is better than random annotator.<br><br>
 """

--- a/src/feedback_forensics/app/plotting_v2/constants.py
+++ b/src/feedback_forensics/app/plotting_v2/constants.py
@@ -43,13 +43,13 @@ the principle relevant to. Ranges from 0 to 1.<br><br>
 <b>Accuracy <i>(acc)</i></b>: Accuracy of principle-following AI annotator <br>
 reconstructing the original annotations, when datapoints are deemed relevant.<br>
 Ranges from 0 to 1.<br><br>
-<b>Cohen's Kappa <i>(kappa)</i></b>: Measures agreement beyond chance between the<br>
+<b>Cohen's kappa <i>(kappa)</i></b>: Measures agreement beyond chance between the<br>
 principle-following AI annotator and original preferences. Calculated as<br>
 kappa=2×(acc-0.5), using 0.5 as the expected agreement by chance for a binary choice.<br>
 Ranges from -1 (perfect disagreement) through 0 (random agreement) to 1 (perfect<br>
 agreement). Unlike principle strength, it doesn't take relevance into account.<br><br>
-<b>Principle strength <i>(strength)</i></b>: Combines Cohen's Kappa and relevance,<br>
-ranges from -1 to 1. Calculated as strength = Cohen's Kappa × relevance, which equals<br>
+<b>Principle strength <i>(strength)</i></b>: Combines Cohen's kappa and relevance,<br>
+ranges from -1 to 1. Calculated as strength = Cohen's kappa × relevance, which equals<br>
 2×(acc-0.5)×relevance. A value of 0 indicates no predictive performance (either due<br>
 to random prediction or low relevance), values below 0 indicate principle-following<br>
 AI annotator is worse than random annotator, and values above 0 indicate<br>

--- a/src/feedback_forensics/app/plotting_v2/constants.py
+++ b/src/feedback_forensics/app/plotting_v2/constants.py
@@ -48,5 +48,10 @@ ranges from -1 to 1. Calculated as perf=(acc-0.5)×rel×2. A value of 0 indicate
 no predictive performance (either due to random prediction or low relevance),<br>
 values below 0 indicate principle-following AI annotator is worse than random<br>
 annotator, and values above 0 indicate principle-following AI annotator is better<br>
-than random annotator.
+than random annotator.<br><br>
+<b>Cohen's Kappa <i>(kappa)</i></b>: Measures agreement beyond chance between the<br>
+principle-following AI annotator and original preferences. Calculated as<br>
+kappa=2×(acc-0.5), using 0.5 as the expected agreement by chance for a binary choice.<br>
+Ranges from -1 (perfect disagreement) through 0 (random agreement) to 1 (perfect<br>
+agreement). Unlike Performance, it doesn't take relevance into account.
 """

--- a/src/feedback_forensics/app/plotting_v2/main.py
+++ b/src/feedback_forensics/app/plotting_v2/main.py
@@ -13,8 +13,8 @@ def generate_plot(
     overall_metrics = {}
     metrics = {}
     for dataset_name, votes_df in votes_df_dict.items():
-        overall_metrics[dataset_name] = feedback_forensics.app.metrics.get_overall_metrics(
-            votes_df
+        overall_metrics[dataset_name] = (
+            feedback_forensics.app.metrics.get_overall_metrics(votes_df)
         )
         metrics[dataset_name] = feedback_forensics.app.metrics.compute_metrics(votes_df)
 

--- a/src/feedback_forensics/app/plotting_v2/table.py
+++ b/src/feedback_forensics/app/plotting_v2/table.py
@@ -26,6 +26,11 @@ AVAIL_METRICS = {
         "color_scale": "berlin",
         "neutral_value": 0.0,
     },
+    "cohens_kappa": {
+        "name": "Cohen's Kappa",
+        "color_scale": "berlin",
+        "neutral_value": 0.0,
+    },
 }
 
 GREY_10 = "#5f5f5f"

--- a/src/feedback_forensics/app/plotting_v2/table.py
+++ b/src/feedback_forensics/app/plotting_v2/table.py
@@ -11,8 +11,8 @@ from feedback_forensics.app.plotting_v2.constants import INFO_ANNOTATION_DESCRIP
 
 # table constants
 AVAIL_METRICS = {
-    "perf": {
-        "name": "Performance",
+    "strength": {
+        "name": "Principle strength (Relevance-weighted Cohen's Kappa)",
         "color_scale": "berlin",
         "neutral_value": 0.0,
     },
@@ -463,12 +463,12 @@ def get_table_contents_from_metrics(metrics: dict[str, dict]) -> dict:
 
     for metric_name, metric_info in list(AVAIL_METRICS.items()) + [
         (
-            "perf (acc|rel)",
+            "strength (acc|rel)",
             None,
         )
     ]:
         # get metrics data
-        if not metric_name == "perf (acc|rel)":
+        if not metric_name == "strength (acc|rel)":
             # Create DataFrame with principles as rows and datasets as columns
             data = pd.DataFrame(
                 {
@@ -487,15 +487,17 @@ def get_table_contents_from_metrics(metrics: dict[str, dict]) -> dict:
 
             view_name = f"{metric_name}  ({dataset_name} ↓)"
 
-            if metric_name == "perf (acc|rel)":
+            if metric_name == "strength (acc|rel)":
                 principles_metrics_dfs[view_name] = (
                     add_combined_metric_to_table_contents(
-                        principles_metrics_dfs[f"perf  ({dataset_name} ↓)"]["data"],
+                        principles_metrics_dfs[f"strength  ({dataset_name} ↓)"]["data"],
                         principles_metrics_dfs[f"acc  ({dataset_name} ↓)"]["data"],
                         principles_metrics_dfs[f"relevance  ({dataset_name} ↓)"][
                             "data"
                         ],
-                        principles_metrics_dfs[f"perf  ({dataset_name} ↓)"]["colors"],
+                        principles_metrics_dfs[f"strength  ({dataset_name} ↓)"][
+                            "colors"
+                        ],
                         sort_by=dataset_name,
                     )
                 )

--- a/src/feedback_forensics/app/plotting_v2/table.py
+++ b/src/feedback_forensics/app/plotting_v2/table.py
@@ -12,7 +12,7 @@ from feedback_forensics.app.plotting_v2.constants import INFO_ANNOTATION_DESCRIP
 # table constants
 AVAIL_METRICS = {
     "strength": {
-        "name": "Principle strength (Relevance-weighted Cohen's Kappa)",
+        "name": "Principle strength (relevance-weighted Cohen's kappa)",
         "color_scale": "berlin",
         "neutral_value": 0.0,
     },
@@ -27,7 +27,7 @@ AVAIL_METRICS = {
         "neutral_value": 0.0,
     },
     "cohens_kappa": {
-        "name": "Cohen's Kappa",
+        "name": "Cohen's kappa",
         "color_scale": "berlin",
         "neutral_value": 0.0,
     },


### PR DESCRIPTION
- Made Cohen's Kappa explicit as a metric (was already implicitly part of perf)
- Renamed "perf" to "principle strength" for clarity - "performance" was misleading since it's not about model performance but how strongly a principle is expressed in the data. The name is still not perfect. "Relevance-weighed Cohen's Kappa" would be better, but is very long.
- Set 50% accuracy for irrelevant principles (neutral value instead of 0)