### PR TITLE
Add ff-data csv_to_ap tool to convert csv to ap

### DIFF
--- a/docs/guide/datasets.ipynb
+++ b/docs/guide/datasets.ipynb
@@ -28,16 +28,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "usage: ff-data [-h] {merge} ...\n",
+      "usage: ff-data [-h] {merge,csv_to_ap} ...\n",
       "\n",
       "Swiss army knife for AnnotatedPairs datasets\n",
       "\n",
       "positional arguments:\n",
-      "  {merge}     Available commands\n",
-      "    merge     Merge two AnnotatedPairs datasets\n",
+      "  {merge,csv_to_ap}  Available commands\n",
+      "    merge            Merge two AnnotatedPairs datasets\n",
+      "    csv_to_ap        Convert CSV to AnnotatedPairs format\n",
       "\n",
       "options:\n",
-      "  -h, --help  show this help message and exit\n"
+      "  -h, --help         show this help message and exit\n"
      ]
     }
    ],

--- a/docs/guide/datasets.ipynb
+++ b/docs/guide/datasets.ipynb
@@ -12,6 +12,7 @@
     "\n",
     "Feedback Forensics provides both CLI and Python API tools for manipulating AnnotatedPairs datasets. This is useful for:\n",
     "\n",
+    "- **Converting CSV data**: Transform preference data from CSV to AnnotatedPairs for use in Feedback Forensics\n",
     "- **Merging datasets**: Combine multiple annotated datasets with overlapping comparisons\n",
     "- **Data restoration**: Merge annotation-only datasets with full comparison data\n",
     "\n",
@@ -44,6 +45,130 @@
    ],
    "source": [
     "!ff-data --help"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Converting CSV to AnnotatedPairs\n",
+    "\n",
+    "Before you can use datasets with Feedback Forensics, they need to be in the AnnotatedPairs format. If you have a raw CSV file with preference data, you can convert it using the `csv_to_ap` command:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "usage: ff-data csv_to_ap [-h] --name NAME csv_file output\n",
+      "\n",
+      "positional arguments:\n",
+      "  csv_file     Input CSV file with columns text_a, text_b, preferred_text\n",
+      "  output       Output AnnotatedPairs JSON file (use \"-\" for stdout)\n",
+      "\n",
+      "options:\n",
+      "  -h, --help   show this help message and exit\n",
+      "  --name NAME  Dataset name for the AnnotatedPairs output\n"
+     ]
+    }
+   ],
+   "source": [
+    "!ff-data csv_to_ap --help"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Your CSV file must contain the required columns:\n",
+    "- `text_a`, `text_b`: The two responses being compared\n",
+    "- `preferred_text`: Which response was preferred (`\"text_a\"` or `\"text_b\"`)\n",
+    "\n",
+    "Optional columns:\n",
+    "- `input` or `prompt`: The prompt that generated the responses\n",
+    "- `model_a`, `model_b`: Names of the models that generated the responses\n",
+    "\n",
+    "Here's an example converting the sample data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "📜  | INFO | Converting CSV to AnnotatedPairs: ../../data/input/example.csv\u001b[0m\n",
+      "/home/vscode/.local/lib/python3.10/site-packages/inverse_cai/data/annotated_pairs_format.py:264: FutureWarning: DataFrame.applymap has been deprecated. Use DataFrame.map instead.\n",
+      "  df = df.applymap(str)  # ensure all columns are hashable\n",
+      "📜  | INFO | Available metadata columns: ['index']\u001b[0m\n",
+      "📜  | INFO | Outputting AnnotatedPairs dataset to stdout\u001b[0m\n",
+      "{\n",
+      "  \"metadata\": {\n",
+      "    \"version\": \"2.0\",\n",
+      "    \"description\": \"Annotated pairs dataset with annotations from ICAI\",\n",
+      "    \"created_at\": \"2025-05-30T16:49:16Z\",\n",
+      "    \"dataset_name\": \"Example Dataset\",\n",
+      "    \"default_annotator\": \"ba751e7b\",\n",
+      "    \"available_metadata_keys_per_comparison\": [\n",
+      "      \"index\"\n",
+      "    ]\n",
+      "  },\n",
+      "  \"annotators\": {\n",
+      "    \"ba751e7b\": {\n",
+      "      \"name\": \"preferred_text\",\n",
+      "      \"description\": \"Default annotator from original dataset (from column `preferred_text`)\",\n",
+      "      \"type\": \"unknown\"\n",
+      "    }\n",
+      "  },\n",
+      "  \"comparisons\": [\n",
+      "    {\n",
+      "      \"id\": \"a4e9e77e\",\n",
+      "      \"prompt\": null,\n",
+      "      \"response_a\": {\n",
+      "        \"text\": \"In the heart of a bustling city, a sleek black cat named Shadow prowled the moonlit rooftops, her eyes gleaming with curiosity and mischief. She discovered a hidden garden atop an old apartment building, where she danced under the stars, chasing fireflies that glowed like tiny lanterns. As dawn painted the sky in hues of orange and pink, Shadow found her way back home, carrying the secret of the garden in her heart.\"\n",
+      "      },\n",
+      "      \"response_b\": {\n",
+      "        \"text\": \"Across the town, in a cozy neighborhood, a golden retriever named Buddy embarked on his daily adventure, tail wagging with uncontainable excitement. He found a lost toy under the bushes in the park, its colors faded and fabric worn, but to Buddy, it was a treasure untold. Returning home with his newfound prize, Buddy's joyful barks filled the air, reminding everyone in the house that happiness can be found in the simplest of things.\"\n",
+      "      },\n",
+      "      \"annotations\": {\n",
+      "        \"ba751e7b\": {\n",
+      "          \"pref\": \"a\"\n",
+      "        }\n",
+      "      },\n",
+      "      \"metadata\": {\n",
+      "        \"index\": \"0\"\n",
+      "      }\n",
+      "    }\n",
+      "  ]\n",
+      "}\n",
+      "📜  | INFO | Successfully converted CSV to AnnotatedPairs\u001b[0m\n",
+      "📜  | INFO | Result contains 1 comparisons and 1 annotators\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "!ff-data csv_to_ap ../../data/input/example.csv - --name \"Example Dataset\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This creates a basic AnnotatedPairs dataset with just the original preferences from your CSV file. **Note: This converted dataset will not include principle-based annotations** - it only contains the original preference data.\n",
+    "\n",
+    "To get rich principle-based annotations that enable personality trait analysis, you should use `ff-annotate` (requiring API keys) instead:\n",
+    "\n",
+    "```bash\n",
+    "ff-annotate --datapath=\"../../data/input/example.csv\"\n",
+    "```\n",
+    "\n",
+    "The `csv_to_ap` command is useful for quick conversion when you want to merge a CSV dataset with annotations in annotated pairs format or when you want to work with just the original preference data without additional AI annotations."
    ]
   },
   {
@@ -467,6 +592,47 @@
     "## Python API\n",
     "\n",
     "The dataset operations are also available through the `feedback_forensics.data.operations` module:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Converting CSV to AnnotatedPairs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "📜  | INFO | Available metadata columns: ['index']\u001b[0m\n",
+      "Converted dataset contains 1 comparisons\n",
+      "Dataset contains 1 annotators\n",
+      "Note: This dataset only contains original preferences, not principle-based annotations\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/vscode/.local/lib/python3.10/site-packages/inverse_cai/data/annotated_pairs_format.py:264: FutureWarning: DataFrame.applymap has been deprecated. Use DataFrame.map instead.\n",
+      "  df = df.applymap(str)  # ensure all columns are hashable\n"
+     ]
+    }
+   ],
+   "source": [
+    "from feedback_forensics.data.operations import csv_to_ap, save_ap\n",
+    "\n",
+    "# Convert CSV to AnnotatedPairs format (without principle annotations)\n",
+    "ap_data = csv_to_ap(\"../../data/input/example.csv\", \"Example Dataset\")\n",
+    "\n",
+    "print(f\"Converted dataset contains {len(ap_data['comparisons'])} comparisons\")\n",
+    "print(f\"Dataset contains {len(ap_data['annotators'])} annotators\")\n",
+    "print(\"Note: This dataset only contains original preferences, not principle-based annotations\")"
    ]
   },
   {

--- a/src/feedback_forensics/data/operations/__init__.py
+++ b/src/feedback_forensics/data/operations/__init__.py
@@ -1,6 +1,6 @@
 """Data operations for AnnotatedPairs datasets."""
 
-from .core import load_ap, save_ap
+from .core import load_ap, save_ap, csv_to_ap
 from .merge import merge_ap
 
-__all__ = ["load_ap", "save_ap", "merge_ap"]
+__all__ = ["load_ap", "save_ap", "csv_to_ap", "merge_ap"]

--- a/src/feedback_forensics/data/operations/core.py
+++ b/src/feedback_forensics/data/operations/core.py
@@ -6,7 +6,9 @@ from typing import Dict, Union, Any
 from inverse_cai.data.annotated_pairs_format import (
     load_annotated_pairs_from_file,
     save_annotated_pairs_to_file,
+    create_annotated_pairs,
 )
+from inverse_cai.data.loader.standard import load
 
 
 def load_ap(file_path: Union[str, Path]) -> Dict[str, Any]:
@@ -36,3 +38,21 @@ def save_ap(data: Dict[str, Any], file_path: Union[str, Path]) -> None:
         ValueError: If data is not valid AnnotatedPairs format
     """
     save_annotated_pairs_to_file(data, Path(file_path))
+
+
+def csv_to_ap(csv_path: Union[str, Path], dataset_name: str) -> Dict[str, Any]:
+    """Convert CSV to AnnotatedPairs format.
+
+    Args:
+        csv_path: Path to CSV file with columns text_a, text_b, preferred_text
+        dataset_name: Name for the dataset
+
+    Returns:
+        AnnotatedPairs data structure
+
+    Raises:
+        FileNotFoundError: If CSV file doesn't exist
+        ValueError: If CSV is missing required columns
+    """
+    df = load(str(csv_path))
+    return create_annotated_pairs(df, dataset_name)

--- a/src/feedback_forensics/data/operations/core_test.py
+++ b/src/feedback_forensics/data/operations/core_test.py
@@ -1,0 +1,53 @@
+"""Tests for core data operations."""
+
+import json
+import pytest
+from pathlib import Path
+
+from feedback_forensics.data.operations.core import csv_to_ap
+
+
+def test_csv_to_ap(tmp_path):
+    """Test CSV to AnnotatedPairs conversion."""
+    csv_content = """text_a,text_b,preferred_text
+"Hello world","Hi there","text_a"
+"Good morning","Good day","text_b"
+"""
+    csv_file = tmp_path / "test.csv"
+    csv_file.write_text(csv_content)
+
+    result = csv_to_ap(csv_file, "Test Dataset")
+
+    assert "metadata" in result
+    assert "annotators" in result
+    assert "comparisons" in result
+
+    assert result["metadata"]["dataset_name"] == "Test Dataset"
+    assert result["metadata"]["version"] == "2.0"
+    assert "created_at" in result["metadata"]
+
+    assert len(result["comparisons"]) == 2
+
+    default_annotator_id = result["metadata"]["default_annotator"]
+
+    comparison1 = result["comparisons"][0]
+    assert comparison1["response_a"]["text"] == "Hello world"
+    assert comparison1["response_b"]["text"] == "Hi there"
+    assert comparison1["annotations"][default_annotator_id]["pref"] == "a"
+
+    comparison2 = result["comparisons"][1]
+    assert comparison2["response_a"]["text"] == "Good morning"
+    assert comparison2["response_b"]["text"] == "Good day"
+    assert comparison2["annotations"][default_annotator_id]["pref"] == "b"
+
+
+def test_csv_to_ap_missing_columns(tmp_path):
+    """Test CSV with missing required columns."""
+    csv_content = """text_a,preferred_text
+"Hello","text_a"
+"""
+    csv_file = tmp_path / "bad.csv"
+    csv_file.write_text(csv_content)
+
+    with pytest.raises(ValueError, match="missing required columns"):
+        csv_to_ap(csv_file, "Test")

--- a/src/feedback_forensics/tools/ff_data.py
+++ b/src/feedback_forensics/tools/ff_data.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from loguru import logger
 import json
 
-from feedback_forensics.data.operations import load_ap, save_ap, merge_ap
+from feedback_forensics.data.operations import load_ap, save_ap, merge_ap, csv_to_ap
 
 
 def merge_command(args):
@@ -41,6 +41,37 @@ def merge_command(args):
     return 0
 
 
+def csv_to_ap_command(args):
+    """Handle csv_to_ap subcommand."""
+    logger.info(f"Converting CSV to AnnotatedPairs: {args.csv_file}")
+
+    try:
+        ap_data = csv_to_ap(args.csv_file, args.name)
+    except FileNotFoundError as e:
+        logger.error(f"CSV file not found: {e}")
+        return 1
+    except ValueError as e:
+        logger.error(f"Invalid CSV format: {e}")
+        return 1
+
+    if args.output == "-":
+        logger.info("Outputting AnnotatedPairs dataset to stdout")
+        print(json.dumps(ap_data, indent=2))
+    else:
+        try:
+            save_ap(ap_data, args.output)
+        except FileNotFoundError as e:
+            logger.error(f"Output directory does not exist.")
+            return 1
+        logger.info(f"Saved AnnotatedPairs dataset to {args.output}")
+
+    logger.info(f"Successfully converted CSV to AnnotatedPairs")
+    logger.info(
+        f"Result contains {len(ap_data['comparisons'])} comparisons and {len(ap_data['annotators'])} annotators"
+    )
+    return 0
+
+
 def main():
     """Main entry point."""
     parser = argparse.ArgumentParser(
@@ -62,6 +93,21 @@ def main():
     merge_parser.add_argument("--name", help="Override dataset name for merged result")
     merge_parser.add_argument("--desc", help="Override description for merged result")
     merge_parser.set_defaults(func=merge_command)
+
+    csv_to_ap_parser = subparsers.add_parser(
+        "csv_to_ap", help="Convert CSV to AnnotatedPairs format"
+    )
+    csv_to_ap_parser.add_argument(
+        "csv_file", help="Input CSV file with columns text_a, text_b, preferred_text"
+    )
+    csv_to_ap_parser.add_argument(
+        "output",
+        help='Output AnnotatedPairs JSON file (use "-" for stdout)',
+    )
+    csv_to_ap_parser.add_argument(
+        "--name", required=True, help="Dataset name for the AnnotatedPairs output"
+    )
+    csv_to_ap_parser.set_defaults(func=csv_to_ap_command)
 
     args = parser.parse_args()
 


### PR DESCRIPTION
This adds python functions, CLI tool, and docs to convert csv to ap. It mostly delegates to ICAI to make it easy to get started on csv files. One use-case is to merge csv files and partial annotated pair files from external sources.